### PR TITLE
feat: Assert witness validation

### DIFF
--- a/babe-programs/soldering/host/src/lib.rs
+++ b/babe-programs/soldering/host/src/lib.rs
@@ -196,11 +196,24 @@ impl BabeBundleBuilder {
         println!("Prover: posting tx_Assert...");
         println!("tx_Assert witness:            {} bytes", assert_witness.size_bytes());
 
+        // Script: validate tx_Assert (simulates Bitcoin script checks).
+        // 1. Check Wots96 sig length.
+        let arr_sig: [[u8; 21]; Wots96::TOTAL_DIGIT_LEN as usize] = assert_witness
+            .wots_sig
+            .clone()
+            .try_into()
+            .map_err(|_| "tx_Assert: wrong Wots96 signature length".to_string())?;
+        // 2. Verify Wots96 sig against the operator public key.
+        let msg = Wots96::signature_to_message(&arr_sig);
+        if !verifiable_circuit_babe::wots::wots96_verify(&verifier_state.wots_pk_p, &msg, &arr_sig) {
+            return Err("tx_Assert: Wots96 signature verification failed".to_string());
+        }
+
         // Verifier: reconstruct the Groth16 proof from tx_Assert and verify it.
         // If valid, no challenge is necessary — the Prover wins the honest path directly.
         // This E2E continues to the challenge path to exercise it end-to-end regardless.
         println!("Verifier: recovering and verifying Groth16 proof from tx_Assert...");
-        match assert_witness.recover_pi1_xd_without_verify() {
+        match assert_witness.try_recover_pi1_xd() {
             None => return Err("tx_Assert: witness is not in correct format (π₁ or x_d malformed)".to_string()),
             Some(_) => {
                 if assert_witness.verify_groth16_proof(&vk, &[static_public_inputs]) {

--- a/verifiable-circuit-babe/src/babe.rs
+++ b/verifiable-circuit-babe/src/babe.rs
@@ -15,7 +15,7 @@ use crate::cac::{
 use crate::wots::{wots96_verify, Wots96, Wots96PublicKey, Wots96Secret};
 use crate::utils::pi1_xd_to_wots96_msg;
 use bitvm::signatures::Wots;
-use crate::dre::N;
+use crate::dre::N_PADDED;
 use crate::prover::BABEProver;
 use crate::soldering::SolderingData;
 use crate::transactions::{ChallengeAssertWitnessRaw, TxAssertWitness, TxChallengeAssertOutputLock, TxChallengeAssertWitness, TxDepositLock, TxWronglyChallengedWitness};
@@ -31,11 +31,8 @@ pub const N_CC: usize = 4;
 /// In practice, M_CC = 7.
 pub const M_CC: usize = 2;
 
-/// Number of real GC input wires: pi1.x + pi1.y + x_d, each `dre::N` bits.
-pub const GC_INPUT_WIRES: usize = 3 * N;
-
-/// `GC_INPUT_WIRES` padded with 6 dummy wires (2 after each `dre::N`-bit group).
-pub const PADDED_INPUT_WIRES: usize = GC_INPUT_WIRES + 6;
+/// Total GC input wires: π₁.x (N_PADDED) + π₁.y (N_PADDED) + x_d (N_PADDED).
+pub const GC_INPUT_WIRES: usize = 3 * N_PADDED;
 
 /// Byte size of a Bitcoin signature placeholder (64 bytes in production).
 pub const BTC_SIG_BYTES: usize = 32;
@@ -247,31 +244,6 @@ pub fn babe_verifier_challenge_assert_cac(
     ))
 }
 
-/// Interleave 6 dummy entries into the [`GC_INPUT_WIRES`]-sized
-/// `pi1_x | pi1_y | x_d` layout to produce the [`PADDED_INPUT_WIRES`]-sized
-/// padded layout: `pi1_x | dummy x2 | pi1_y | dummy x2 | x_d | dummy x2`.
-pub fn interleave_dummy_positions<T: Clone>(pi1_x: &[T], pi1_y: &[T], x_d: &[T], dummy: T) -> Vec<T> {
-    assert_eq!(pi1_x.len(), N);
-    assert_eq!(pi1_y.len(), N);
-    assert_eq!(x_d.len(), N);
-    pi1_x.iter().cloned()
-        .chain([dummy.clone(), dummy.clone()])
-        .chain(pi1_y.iter().cloned())
-        .chain([dummy.clone(), dummy.clone()])
-        .chain(x_d.iter().cloned())
-        .chain([dummy.clone(), dummy.clone()])
-        .collect()
-}
-
-/// Inverse of [`interleave_dummy_positions`]
-pub fn deinterleave_dummy_positions<T: Clone>(padded: &[T]) -> (Vec<T>, Vec<T>, Vec<T>) {
-    assert_eq!(padded.len(), PADDED_INPUT_WIRES);
-    let pi1_x = padded[..N].to_vec();
-    let pi1_y = padded[N + 2..2 * N + 2].to_vec();
-    let x_d = padded[2 * N + 4..3 * N + 4].to_vec();
-    (pi1_x, pi1_y, x_d)
-}
-
 /// Build the ChallengeAssert witness from a pre-validated Assert witness.
 /// Caller is responsible for verifying the Wots96 signature before invoking this.
 pub fn build_challenge_assert_witness(
@@ -304,10 +276,8 @@ pub fn babe_prover_wrongly_challenged_cac(
     prover_state: &ProverSetupState,
 ) -> Option<(TxWronglyChallengedWitness, usize)> {
     let base_input_labels: Vec<S> = challenge_witness.witness.input_labels.iter().map(|&b| S(b)).collect();
-    // Drop the MSB-slot labels at positions 254-255, 510-511, 766-767 (always 0 for valid fields).
-    // The GC currently takes only the 254 real bits per coordinate; Step 2 removes this strip.
-    let (pi1_x_labels, pi1_y_labels, x_d_labels) = deinterleave_dummy_positions(&base_input_labels);
-    let pi1_labels: Vec<S> = pi1_x_labels.into_iter().chain(pi1_y_labels).collect();
+    let pi1_labels = base_input_labels[..2 * N_PADDED].to_vec();
+    let x_d_labels = base_input_labels[2 * N_PADDED..].to_vec();
     let mut prover = BABEProver::new(vk.clone(), proof.clone(), dyn_pubin);
     let found = prover.check_compute_msg(
         &prover_state.finalized,

--- a/verifiable-circuit-babe/src/babe.rs
+++ b/verifiable-circuit-babe/src/babe.rs
@@ -231,12 +231,20 @@ pub fn babe_verifier_challenge_assert_cac(
     assert_witness: &TxAssertWitness,
     verifier_state: &VerifierSetupState,
 ) -> Option<TxChallengeAssertWitness> {
-    build_challenge_assert_witness(
+    // Simulate Bitcoin script: validate Wots96 sig length and verify against the operator pubkey.
+    let arr_sig: [[u8; 21]; Wots96::TOTAL_DIGIT_LEN as usize] =
+        assert_witness.wots_sig.clone().try_into().ok()?;
+    let msg = Wots96::signature_to_message(&arr_sig);
+    tracing::info!("Verifier: Checking Wots96 signature in tx_Assert...");
+    if !wots96_verify(&verifier_state.wots_pk_p, &msg, &arr_sig) {
+        return None;
+    }
+
+    Some(build_challenge_assert_witness(
         &verifier_state.verifier,
         assert_witness,
-        &verifier_state.wots_pk_p,
-        verifier_state.finalized_indices[0]
-    )
+        verifier_state.finalized_indices[0],
+    ))
 }
 
 /// Interleave 6 dummy entries into the [`GC_INPUT_WIRES`]-sized
@@ -264,60 +272,24 @@ pub fn deinterleave_dummy_positions<T: Clone>(padded: &[T]) -> (Vec<T>, Vec<T>, 
     (pi1_x, pi1_y, x_d)
 }
 
+/// Build the ChallengeAssert witness from a pre-validated Assert witness.
+/// Caller is responsible for verifying the Wots96 signature before invoking this.
 pub fn build_challenge_assert_witness(
     verifier: &BABEVerifier,
     assert_witness: &TxAssertWitness,
-    operator_wots_pubkey: &Wots96PublicKey,
     base_idx: usize,
-) -> Option<TxChallengeAssertWitness> {
-    let witness = build_challenge_assert_witness_raw(
-        verifier, assert_witness, operator_wots_pubkey, base_idx,
-    );
-    if witness.is_none() {
-        None
-    } else {
-        Some(TxChallengeAssertWitness {
-            witness: witness.unwrap(),
-            sig_v: BabeBtcSig::VerifierLiveSig,
-            sig_p: BabeBtcSig::ProverPresigChallengeAssert,
-        })
+) -> TxChallengeAssertWitness {
+    let arr_sig: [[u8; 21]; Wots96::TOTAL_DIGIT_LEN as usize] =
+        assert_witness.wots_sig.clone().try_into()
+            .expect("caller must ensure wots_sig has the correct length");
+    let msg = Wots96::signature_to_message(&arr_sig);
+    let labels = verifier.compute_labels_from_bytes(base_idx, &msg);
+    let input_labels: Vec<[u8; 16]> = labels.into_iter().map(|s| s.0).collect();
+    TxChallengeAssertWitness {
+        witness: ChallengeAssertWitnessRaw { input_labels, wots_sig: arr_sig.to_vec() },
+        sig_v: BabeBtcSig::VerifierLiveSig,
+        sig_p: BabeBtcSig::ProverPresigChallengeAssert,
     }
-}
-
-pub fn build_challenge_assert_witness_raw(
-    verifier: &BABEVerifier,
-    assert_witness: &TxAssertWitness,
-    operator_wots_pubkey: &Wots96PublicKey,
-    base_idx: usize,
-) -> Option<ChallengeAssertWitnessRaw> {
-    let (pi1, x_d) = assert_witness.recover_pi1_xd_without_verify()?;
-
-    let msg = pi1_xd_to_wots96_msg(&pi1, x_d);
-    tracing::info!("Verifier: Checking Wots96 signature in tx_Assert against pi1, x_d and wots_pk_p...");
-    assert_eq!(assert_witness.wots_sig.len(), Wots96::TOTAL_DIGIT_LEN as usize);
-    let arr_sig: [[u8; 21]; Wots96::TOTAL_DIGIT_LEN as usize] = assert_witness.wots_sig.clone().try_into().unwrap();
-    if !wots96_verify(operator_wots_pubkey, &msg, &arr_sig) {
-        return None;
-    }
-
-    let pi1_labels = verifier.compute_pi1_labels(base_idx, pi1);
-    let x_d_labels = verifier.compute_x_d_labels(base_idx, x_d);
-    // hardcoded for both Prover and Verifier.
-    let dummy = S([0u8; 16]);
-    let input_labels: Vec<[u8; 16]> = interleave_dummy_positions(
-        &pi1_labels[..N],
-        &pi1_labels[N..],
-        &x_d_labels,
-        dummy,
-    )
-    .into_iter()
-    .map(|s| s.0)
-    .collect();
-
-    Some(ChallengeAssertWitnessRaw {
-        input_labels,
-        wots_sig: arr_sig.to_vec(),
-    })
 }
 
 // ─── WronglyChallenged phase (Prover decrypts msg via C&C) ───────────────────
@@ -332,7 +304,8 @@ pub fn babe_prover_wrongly_challenged_cac(
     prover_state: &ProverSetupState,
 ) -> Option<(TxWronglyChallengedWitness, usize)> {
     let base_input_labels: Vec<S> = challenge_witness.witness.input_labels.iter().map(|&b| S(b)).collect();
-    // Strip the 6 dummy labels before passing to the GC (which has GC_INPUT_WIRES real wires).
+    // Drop the MSB-slot labels at positions 254-255, 510-511, 766-767 (always 0 for valid fields).
+    // The GC currently takes only the 254 real bits per coordinate; Step 2 removes this strip.
     let (pi1_x_labels, pi1_y_labels, x_d_labels) = deinterleave_dummy_positions(&base_input_labels);
     let pi1_labels: Vec<S> = pi1_x_labels.into_iter().chain(pi1_y_labels).collect();
     let mut prover = BABEProver::new(vk.clone(), proof.clone(), dyn_pubin);

--- a/verifiable-circuit-babe/src/dre/mod.rs
+++ b/verifiable-circuit-babe/src/dre/mod.rs
@@ -3,6 +3,8 @@ use ark_bn254::Fq;
 pub mod utils;
 pub mod matrices;
 pub const N: usize = 254;
+/// Padded input width per field element: 254 real bits + 2 MSB slots checked by the GC.
+pub const N_PADDED: usize = 256;
 pub const U_BAR_SIZE: usize = 1 + 5 * N; // 1271 — ū(π) binary decomposition
 pub const Q_SIZE: usize = 2 * N;       // 508  — standard affine (x,y) of x_d·L_2 + B
 

--- a/verifiable-circuit-babe/src/gc/artifact.rs
+++ b/verifiable-circuit-babe/src/gc/artifact.rs
@@ -1,6 +1,5 @@
 use std::fs;
 use ark_bn254::G1Affine;
-use ark_ec::AffineRepr;
 use garbled_snark_verifier::core::utils::{reset_gid, SerializableGate};
 
 use super::circuit::{compile_fgc, compile_sgc_part1, FGC_NUM_PRE_INITIALIZED, SGC_NUM_PRE_INITIALIZED};
@@ -158,11 +157,10 @@ fn print_report(stats: &[CircuitStats; 2]) {
 /// Generate, compact, and write all circuit artifacts from scratch.
 pub fn generate_compact_artifacts(l2_point: G1Affine) -> [CircuitStats; 2] {
     reset_gid();
-    let g = G1Affine::generator();
 
     // ── FGC ──────────────────────────────────────────────────────────────────
     println!("[1/6] Compiling FGC...");
-    let (bld, fgc_out_idx) = compile_fgc(g);
+    let (bld, fgc_out_idx) = compile_fgc();
     let (mut fgc_num_wires, mut fgc_gates, mut fgc_out_idx) =
         compile_to_flat(bld.build(&[]), fgc_out_idx);
     let fgc_wires_orig = fgc_num_wires as usize;
@@ -232,6 +230,7 @@ pub fn generate_compact_artifacts(l2_point: G1Affine) -> [CircuitStats; 2] {
 
 #[cfg(test)]
 mod tests {
+    use ark_ec::AffineRepr;
     use super::*;
 
     #[test]

--- a/verifiable-circuit-babe/src/gc/circuit.rs
+++ b/verifiable-circuit-babe/src/gc/circuit.rs
@@ -1,14 +1,14 @@
 use ark_bn254::G1Affine;
-use ark_ec::CurveGroup;
+use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{AdditiveGroup, Zero};
 use sha2::{Digest, Sha256};
 use garbled_snark_verifier::circuits::sect233k1::builder::{CircuitAdapter, CircuitTrait};
-use garbled_snark_verifier::dv_bn254::basic::selector;
+use garbled_snark_verifier::dv_bn254::basic::{not, selector};
 use garbled_snark_verifier::dv_bn254::fp254impl::Fp254Impl;
 use garbled_snark_verifier::dv_bn254::{fq::Fq, fr::Fr};
 use garbled_snark_verifier::dv_bn254::g1::{projective_to_affine_montgomery, G1Projective as GcG1Projective, G1Projective};
 
-use crate::dre::{N, Q_SIZE, U_BAR_SIZE};
+use crate::dre::{N, N_PADDED, Q_SIZE, U_BAR_SIZE};
 
 // Unsigned 8-bit windowed scalar-mul parameters. Must match the `SCALAR_WINDOW_*`
 // constants in garbled-snark-verifier's dv_bn254::g1. With w=8 we do 32 mixed-adds
@@ -22,8 +22,8 @@ pub const SGC_PART1_CONSTANT_SIZE: usize = 2 + 2 * N; // 0/1 + B.
 /// Number of wires initialized before the garbling loop in each circuit.
 /// These are assigned slots 0..N-1 by the liveness allocator and must match
 /// the `set_label` indices used in `CACInstance::new_from_seed` / `commit_from_seed`.
-pub const FGC_NUM_PRE_INITIALIZED: usize = 2 + 2 * N;          // wire0, wire1, π_x(N), π_y(N)
-pub const SGC_NUM_PRE_INITIALIZED: usize = SGC_PART1_CONSTANT_SIZE + Fr::N_BITS; // wire0,1 + B + x_d
+pub const FGC_NUM_PRE_INITIALIZED: usize = 2 + 2 * N_PADDED;   // wire0, wire1, π_x(N_PADDED), π_y(N_PADDED)
+pub const SGC_NUM_PRE_INITIALIZED: usize = SGC_PART1_CONSTANT_SIZE + N_PADDED; // wire0,1 + B + x_d
 
 
 // ── Circuit 1 / FGC ────────────────────────────────────────────────────────
@@ -37,22 +37,24 @@ pub const SGC_NUM_PRE_INITIALIZED: usize = SGC_PART1_CONSTANT_SIZE + Fr::N_BITS;
 /// `g` is the fallback point, embedded as constant wires.
 ///
 /// Output: U_BAR_SIZE bits — ū(π) when π is on the curve, ū(g) otherwise.
-pub fn compile_fgc(g: G1Affine) -> (CircuitAdapter, Vec<usize>) {
+pub fn compile_fgc() -> (CircuitAdapter, Vec<usize>) {
     let mut bld = CircuitAdapter::default();
 
-    let pi_x = Fq::wires(&mut bld);
-    let pi_y = Fq::wires(&mut bld);
+    let pi_x_all: Vec<usize> = (0..N_PADDED).map(|_| bld.fresh_one()).collect();
+    let pi_y_all: Vec<usize> = (0..N_PADDED).map(|_| bld.fresh_one()).collect();
 
-    let output_indices = emit_fgc(&mut bld, &pi_x.0, &pi_y.0, g);
+    let output_indices = emit_fgc(&mut bld, &pi_x_all, &pi_y_all);
     (bld, output_indices)
 }
 
 fn emit_fgc(
     bld: &mut CircuitAdapter,
-    pi_x: &[usize],
-    pi_y: &[usize],
-    g: G1Affine,
+    pi_x_all: &[usize],
+    pi_y_all: &[usize],
 ) -> Vec<usize> {
+    let pi_x = &pi_x_all[..N];
+    let pi_y = &pi_y_all[..N];
+
     // R² mod p — converts normal → Montgomery form
     let r_sq = Fq::as_montgomery(Fq::as_montgomery(ark_bn254::Fq::from(1u64)));
 
@@ -68,6 +70,13 @@ fn emit_fgc(
     let rhs_m    = Fq::add_constant(bld, &x_cu_m, three_mont);
     let on_curve = Fq::equal(bld, &y_sq_m, &rhs_m);
 
+    // MSB slots (bits N and N+1 of each coordinate) must be zero for a valid field element.
+    let any_msb_x = bld.or_wire(pi_x_all[N], pi_x_all[N + 1]);
+    let any_msb_y = bld.or_wire(pi_y_all[N], pi_y_all[N + 1]);
+    let any_msb   = bld.or_wire(any_msb_x, any_msb_y);
+    let msb_ok    = not(bld, any_msb);
+    let valid     = bld.and_wire(on_curve, msb_ok);
+
     // montgomery_reduce(A·R ‖ 0) = A — converts back to standard form
     let x_sq = Fq::mul_by_constant_montgomery(bld, &x_sq_m, ark_bn254::Fq::from(1u64));
     let y_sq = Fq::mul_by_constant_montgomery(bld, &y_sq_m, ark_bn254::Fq::from(1u64));
@@ -82,10 +91,10 @@ fn emit_fgc(
     pi_u_bar.extend(xy);
     assert_eq!(pi_u_bar.len(), U_BAR_SIZE);
 
-    let g_u_bar = g_u_bar_indices(bld, g);
+    let g_u_bar = g_u_bar_indices(bld);
 
     (0..U_BAR_SIZE)
-        .map(|k| selector(bld, pi_u_bar[k], g_u_bar[k], on_curve))
+        .map(|k| selector(bld, pi_u_bar[k], g_u_bar[k], valid))
         .collect()
 }
 
@@ -93,15 +102,16 @@ fn emit_fgc(
 
 /// Compile SGC Part 1: computes Q = x_d · L_2 + B.
 ///
-/// `l2` is fixed (like `g` in FGC) and is embedded as constant wires.
+/// `l2` is fixed and is embedded as constant wires.
 /// B is garbler-private and supplied as input wires.
 ///
 /// Input wire layout:
-///   [0..Fr::N_BITS)           B_x — x-coordinate of B, Montgomery form (garbler-private)
-///   [Fr::N_BITS..Fr::N_BITS+N)     B_y — y-coordinate of B, Montgomery form (garbler-private)
-///   [Fr::N_BITS+N..Fr::N_BITS+2·N)  x_d — scalar bits, LSB-first (evaluator input)
+///   [0..N)            B_x — x-coordinate of B, Montgomery form (garbler-private)
+///   [N..2·N)          B_y — y-coordinate of B, Montgomery form (garbler-private)
+///   [2·N..2·N+N_PADDED) x_d — scalar bits LSB-first + 2 MSB slots (evaluator input)
 ///
-/// Output: Q_SIZE = 2·N bits — (x, y) of Q in standard affine form.
+/// Output: Q_SIZE = 2·N bits — (x, y) of Q in standard affine form,
+///         or G1 generator if any MSB slot is non-zero.
 pub fn compile_sgc_part1(l2: G1Affine) -> (CircuitAdapter, Vec<usize>) {
     let mut bld = CircuitAdapter::default();
 
@@ -109,17 +119,32 @@ pub fn compile_sgc_part1(l2: G1Affine) -> (CircuitAdapter, Vec<usize>) {
     let b_x = Fq::wires(&mut bld);
     let b_y = Fq::wires(&mut bld);
 
-    // x_d — evaluator input
-    let x_d: Vec<usize> = (0..Fr::N_BITS).map(|_| bld.fresh_one()).collect();
+    let x_d: Vec<usize> = (0..N_PADDED).map(|_| bld.fresh_one()).collect();
 
-    // L_2 table — embedded as constant wires, same pattern as g in compile_fgc
+    // MSB slots must be zero for a valid Fr scalar.
+    let any_msb = bld.or_wire(x_d[N], x_d[N + 1]);
+    let msb_ok  = not(&mut bld, any_msb);
+
+    // L_2 table — embedded as constant wires
     let table_wires: Vec<usize> = build_l2_table_bits(&l2)
         .into_iter()
         .map(|bit| if bit { bld.one() } else { bld.zero() })
         .collect();
     assert_eq!(table_wires.len(), PRECOMP_TABLE_BITS);
 
-    let output_indices = emit_scalar_mul_then_add(&mut bld, &x_d, &b_x.0, &b_y.0, &table_wires);
+    let q_output = emit_scalar_mul_then_add(&mut bld, &x_d[..N], &b_x.0, &b_y.0, &table_wires);
+
+    // Fallback to G1 generator when MSBs are non-zero.
+    let generator = G1Affine::generator();
+    let gen_output: Vec<usize> = Fq::to_bits(generator.x).into_iter()
+        .chain(Fq::to_bits(generator.y))
+        .map(|b| if b { bld.one() } else { bld.zero() })
+        .collect();
+    assert_eq!(gen_output.len(), Q_SIZE);
+
+    let output_indices: Vec<usize> = q_output.iter().zip(gen_output.iter())
+        .map(|(&real, &fallback)| selector(&mut bld, real, fallback, msb_ok))
+        .collect();
     (bld, output_indices)
 }
 
@@ -166,8 +191,9 @@ fn emit_scalar_mul_then_add(
     output
 }
 
-/// Build constant wire indices for ū(g).
-fn g_u_bar_indices(bld: &mut CircuitAdapter, g: G1Affine) -> Vec<usize> {
+/// Build constant wire indices for ū(G1 generator) — the fallback output.
+fn g_u_bar_indices(bld: &mut CircuitAdapter) -> Vec<usize> {
+    let g    = G1Affine::generator();
     let x    = g.x;
     let y    = g.y;
     let x_sq = x * x;
@@ -239,18 +265,19 @@ mod tests {
 
     // ── FGC witness / tests ─────────────────────────────────────────────────
 
-    /// Witness for compile_fgc: only π_x and π_y.
+    /// Witness for compile_fgc: π_x (N bits) + 2 MSB zeros, π_y (N bits) + 2 MSB zeros.
     fn fgc_witness(pi: &G1Affine) -> Vec<bool> {
-        Fq::to_bits(pi.x)
-            .into_iter()
+        Fq::to_bits(pi.x).into_iter()
+            .chain([false, false])
             .chain(Fq::to_bits(pi.y))
+            .chain([false, false])
             .collect()
     }
 
-    fn eval_fgc(pi: &G1Affine, g: G1Affine) -> Vec<bool> {
+    fn eval_fgc(pi: &G1Affine) -> Vec<bool> {
         let witness = fgc_witness(pi);
         reset_gid();
-        let (bld, output_indices) = compile_fgc(g);
+        let (bld, output_indices) = compile_fgc();
         assert_eq!(output_indices.len(), U_BAR_SIZE);
         let mut circuit = bld.build(&witness);
         for gate in &mut circuit.1 { gate.evaluate(); }
@@ -260,8 +287,7 @@ mod tests {
     #[test]
     fn test_fgc_on_curve() {
         let pi = random_g1_affine();
-        let g  = random_g1_affine();
-        let output = eval_fgc(&pi, g);
+        let output = eval_fgc(&pi);
 
         assert_eq!(output.len(), U_BAR_SIZE);
         assert!(output[0], "u₀ must be 1");
@@ -282,34 +308,61 @@ mod tests {
     #[test]
     fn test_fgc_off_curve_falls_back_to_g() {
         let pi = random_g1_affine();
-        let g  = random_g1_affine();
 
         let mut off_pi = pi;
         off_pi.y += ark_bn254::Fq::from(1u64);
-        let output = eval_fgc(&off_pi, g);
+        let output = eval_fgc(&off_pi);
 
         assert_eq!(output.len(), U_BAR_SIZE);
         assert!(output[0], "u₀ must be 1");
 
+        let g = G1Affine::generator();
         let gx_bits = Fq::to_bits(g.x);
         for k in 0..N {
-            assert_eq!(output[1 + k], gx_bits[k], "g.x bit {k} mismatch");
+            assert_eq!(output[1 + k], gx_bits[k], "generator.x bit {k} mismatch");
         }
         let gy_bits = Fq::to_bits(g.y);
         for k in 0..N {
-            assert_eq!(output[1 + N + k], gy_bits[k], "g.y bit {k} mismatch");
+            assert_eq!(output[1 + N + k], gy_bits[k], "generator.y bit {k} mismatch");
+        }
+    }
+
+    #[test]
+    fn test_fgc_msb_nonzero_falls_back_to_generator() {
+        let pi = random_g1_affine(); // valid on-curve point
+        let mut witness = fgc_witness(&pi);
+        witness[N] = true; // pi_x MSB slot 0 = 1
+
+        reset_gid();
+        let (bld, output_indices) = compile_fgc();
+        let mut circuit = bld.build(&witness);
+        for gate in &mut circuit.1 { gate.evaluate(); }
+        let output: Vec<bool> = output_indices.iter()
+            .map(|&i| circuit.0[i].borrow().get_value()).collect();
+
+        assert_eq!(output.len(), U_BAR_SIZE);
+        assert!(output[0], "u₀ must be 1");
+        let g = G1Affine::generator();
+        let gx_bits = Fq::to_bits(g.x);
+        for k in 0..N {
+            assert_eq!(output[1 + k], gx_bits[k], "generator.x bit {k} mismatch");
+        }
+        let gy_bits = Fq::to_bits(g.y);
+        for k in 0..N {
+            assert_eq!(output[1 + N + k], gy_bits[k], "generator.y bit {k} mismatch");
         }
     }
 
     // ── SGC Part 1 witness / tests ──────────────────────────────────────────
 
-    /// Witness for compile_sgc_part1: x_d | B_x (Montgomery) | B_y (Montgomery).
+    /// Witness for compile_sgc_part1: B_x (Montgomery) | B_y (Montgomery) | x_d (N bits) + 2 MSB zeros.
     /// L_2 table is baked into the circuit as constants, so it is not part of the witness.
     fn sgc_part1_witness(x_d: ark_bn254::Fr, b: &G1Affine) -> Vec<bool> {
         Fq::to_bits(Fq::as_montgomery(b.x))
             .into_iter()
             .chain(Fq::to_bits(Fq::as_montgomery(b.y)))
             .chain(Fr::to_bits(x_d))
+            .chain([false, false])
             .collect()
     }
 
@@ -359,5 +412,32 @@ mod tests {
             .into_affine();
 
         assert_eq!(got, expected, "Q = 1·L₂ + B should equal L₂ + B");
+    }
+
+    #[test]
+    fn test_sgc_part1_xd_msb_nonzero_falls_back_to_generator() {
+        let mut rng = rand::thread_rng();
+        let l2 = random_g1_affine();
+        let b  = random_g1_affine();
+        let x_d = ark_bn254::Fr::rand(&mut rng);
+
+        let mut witness = sgc_part1_witness(x_d, &b);
+        // sgc_part1_witness layout: B_x (N) | B_y (N) | x_d (N) | false, false
+        // x_d MSB slot 0 is at index 2*N + N = 762
+        witness[2 * N + N] = true;
+
+        reset_gid();
+        let (bld, output_indices) = compile_sgc_part1(l2);
+        let mut circuit = bld.build(&witness);
+        for gate in &mut circuit.1 { gate.evaluate(); }
+
+        let bits: Vec<bool> = output_indices.iter()
+            .map(|&i| circuit.0[i].borrow().get_value()).collect();
+        let x = Fq::from_bits(bits[..N].to_vec());
+        let y = Fq::from_bits(bits[N..2 * N].to_vec());
+        let result = ark_bn254::G1Affine::new_unchecked(x, y);
+
+        assert_eq!(result, ark_bn254::G1Affine::generator(),
+                   "SGC Part 1 should fall back to G1 generator when x_d MSB is set");
     }
 }

--- a/verifiable-circuit-babe/src/instance/mod.rs
+++ b/verifiable-circuit-babe/src/instance/mod.rs
@@ -242,29 +242,25 @@ impl CACInstance {
     /// Returns the input labels given the bits of pi1.
     /// Use for testing.
     pub fn compute_pi1_labels_based_on_value(&self, pi1: ark_bn254::G1Affine) -> Vec<S> {
-        let x_bits = DvFq::to_bits(pi1.x);
-        let y_bits = DvFq::to_bits(pi1.y);
-        let witness: Vec<bool> = x_bits.into_iter().chain(y_bits).collect();
+        let witness: Vec<bool> = DvFq::to_bits(pi1.x).into_iter().chain([false, false])
+            .chain(DvFq::to_bits(pi1.y)).chain([false, false])
+            .collect();
         let delta = self.secrets.delta[0];
-
-        let labels: Vec<S> = witness.iter().enumerate().map(|(i, &b)| {
+        witness.iter().enumerate().map(|(i, &b)| {
             let key = self.secrets.input_0labels[0][i];
             if b { key ^ delta } else { key }
-        }).collect();
-        labels
+        }).collect()
     }
 
     /// Returns the input labels given the bits of pi1.
     /// Use for testing.
     pub fn compute_x_d_labels_based_on_value(&self, x_d: Fr) -> Vec<S> {
-        let witness = DvFr::to_bits(x_d);
+        let witness: Vec<bool> = DvFr::to_bits(x_d).into_iter().chain([false, false]).collect();
         let delta = self.secrets.delta[1];
-
-        let labels: Vec<S> = witness.iter().enumerate().map(|(i, &b)| {
+        witness.iter().enumerate().map(|(i, &b)| {
             let key = self.secrets.input_0labels[1][i];
             if b { key ^ delta } else { key }
-        }).collect();
-        labels
+        }).collect()
     }
 
     pub fn get_b_value_labels(&self) -> Vec<S> {
@@ -372,9 +368,8 @@ mod tests {
         for (i, &lbl) in pi1_labels.iter().enumerate() {
             fgc.0[i + 2].borrow_mut().label = Some(lbl);
         }
-        let fgc_witness: Vec<bool> = DvFq::to_bits(pi1.x)
-            .into_iter()
-            .chain(DvFq::to_bits(pi1.y).into_iter())
+        let fgc_witness: Vec<bool> = DvFq::to_bits(pi1.x).into_iter().chain([false, false])
+            .chain(DvFq::to_bits(pi1.y)).chain([false, false])
             .collect();
         let fgc_output_labels = BABEProver::eval_circuit_with_ciphertext(
             &mut fgc,
@@ -403,7 +398,7 @@ mod tests {
         for (i, bit) in b_y_bits.iter().enumerate() {
             sgc.0[2 + 254 + i].borrow_mut().value = Some(*bit);
         }
-        let sgc_part1_witness: Vec<bool> = DvFr::to_bits(dynamic_inputs);
+        let sgc_part1_witness: Vec<bool> = DvFr::to_bits(dynamic_inputs).into_iter().chain([false, false]).collect();
         let sgc_output_labels_1 = BABEProver::eval_circuit_with_ciphertext(
             &mut sgc,
             &sgc_indices,
@@ -429,9 +424,8 @@ mod tests {
             fgc.0[2 + i].borrow_mut().label = Some(S(key));
         }
         set_gc_const_labels(&mut fgc, &constant_labels[1][0..2]);
-        let sgc_witness: Vec<bool> = DvFq::to_bits(q_affine.x)
-            .into_iter()
-            .chain(DvFq::to_bits(q_affine.y).into_iter())
+        let sgc_witness: Vec<bool> = DvFq::to_bits(q_affine.x).into_iter().chain([false, false])
+            .chain(DvFq::to_bits(q_affine.y)).chain([false, false])
             .collect();
         let sgc_output_labels_2 = BABEProver::eval_circuit_with_ciphertext(
             &mut fgc,

--- a/verifiable-circuit-babe/src/instance/mod.rs
+++ b/verifiable-circuit-babe/src/instance/mod.rs
@@ -9,7 +9,7 @@ use ark_groth16::VerifyingKey as Groth16VerifyingKey;
 use ark_serialize::CanonicalSerialize;
 use garbled_snark_verifier::dv_bn254::fq::Fq as DvFq;
 use garbled_snark_verifier::dv_bn254::fr::Fr as DvFr;
-use crate::dre::{Q_SIZE, U_BAR_SIZE};
+use crate::dre::{N, Q_SIZE, U_BAR_SIZE};
 use crate::instance::commit::CACInstanceCommit;
 use crate::utils::{derive_hashlock, g2_project_to_ser, h_256, ro_from_pairing_bytes};
 
@@ -79,9 +79,7 @@ impl CACInstance {
             let mut buf = FlatEvalBuffer::new(fgc_flat.num_wires);
             buf.set_label(0, secrets.constant_0labels[1][0].0);
             buf.set_label(1, secrets.constant_0labels[1][1].0);
-            for (i, key) in sgc_output_labels_1.iter().step_by(2).enumerate() {
-                buf.set_label(2 + i, *key);
-            }
+            set_sgc2_rq_labels(&mut buf, &sgc_output_labels_1, secrets.constant_0labels[1][0].0);
             buf.garble_and_collect(fgc_flat, fgc_indices, secrets.delta[1].0)
         };
         assert_eq!(sgc_output_labels_2.len(), 2 * U_BAR_SIZE);
@@ -149,9 +147,7 @@ impl CACInstance {
             let mut buf = FlatEvalBuffer::new(fgc_flat.num_wires);
             buf.set_label(0, secrets.constant_0labels[1][0].0);
             buf.set_label(1, secrets.constant_0labels[1][1].0);
-            for (i, key) in sgc_output_labels_1.iter().step_by(2).enumerate() {
-                buf.set_label(2 + i, *key);
-            }
+            set_sgc2_rq_labels(&mut buf, &sgc_output_labels_1, secrets.constant_0labels[1][0].0);
             buf.garble_and_hash(fgc_flat, fgc_indices, secrets.delta[1].0)
         };
         assert_eq!(sgc_output_labels_2.len(), 2 * U_BAR_SIZE);
@@ -305,6 +301,23 @@ impl CACInstance {
     }
 }
 
+/// Set SGC Part 2 input 0-labels
+/// Wire layout: Q.x bits (0..N) | Q.x MSB slots | Q.y bits (0..N) | Q.y MSB slots.
+/// `q_pairs` is the interleaved [l0, l1, l0, l1, ...] output from SGC Part 1 (2*Q_SIZE entries).
+/// `msb_l0` is the 0-label for the 4 MSB-slot wires/
+fn set_sgc2_rq_labels(buf: &mut FlatEvalBuffer, q_pairs: &[[u8; 16]], msb_l0: [u8; 16]) {
+    for (i, key) in q_pairs[..2 * N].iter().step_by(2).enumerate() {
+        buf.set_label(2 + i, *key);
+    }
+    buf.set_label(2 + N, msb_l0);
+    buf.set_label(2 + N + 1, msb_l0);
+    for (i, key) in q_pairs[2 * N..].iter().step_by(2).enumerate() {
+        buf.set_label(2 + N + 2 + i, *key);
+    }
+    buf.set_label(2 + N + 2 + N, msb_l0);
+    buf.set_label(2 + N + 2 + N + 1, msb_l0);
+}
+
 pub fn set_gc_const_labels(
     circuit: &mut Circuit,
     constant_labels: &[S],
@@ -317,6 +330,21 @@ pub fn set_gc_const_labels(
     for i in 0..constant_labels.len() {
         circuit.0[i].borrow_mut().label = Some(constant_labels[i]);
     }
+}
+
+/// Set SGC Part 2 input labels on a Circuit for evaluation.
+/// same layout as set_sgc2_q_labels
+pub fn set_sgc2_rq_eval_labels(circuit: &mut Circuit, q_labels: &[[u8; 16]], msb_label: S) {
+    for (i, &key) in q_labels[..N].iter().enumerate() {
+        circuit.0[2 + i].borrow_mut().label = Some(S(key));
+    }
+    circuit.0[2 + N].borrow_mut().label = Some(msb_label);
+    circuit.0[2 + N + 1].borrow_mut().label = Some(msb_label);
+    for (i, &key) in q_labels[N..].iter().enumerate() {
+        circuit.0[2 + N + 2 + i].borrow_mut().label = Some(S(key));
+    }
+    circuit.0[2 + N + 2 + N].borrow_mut().label = Some(msb_label);
+    circuit.0[2 + N + 2 + N + 1].borrow_mut().label = Some(msb_label);
 }
 
 
@@ -419,11 +447,8 @@ mod tests {
 
         // evaluate the sgc part2 to get the r * Q
         fgc.reset_circuit_except_01_constants();
-        // set label of part2 as output of part1 (evaluator has one active label per wire)
-        for (i, &key) in sgc_output_labels_1.iter().enumerate()  {
-            fgc.0[2 + i].borrow_mut().label = Some(S(key));
-        }
         set_gc_const_labels(&mut fgc, &constant_labels[1][0..2]);
+        set_sgc2_rq_eval_labels(&mut fgc, &sgc_output_labels_1, constant_labels[1][0]);
         let sgc_witness: Vec<bool> = DvFq::to_bits(q_affine.x).into_iter().chain([false, false])
             .chain(DvFq::to_bits(q_affine.y)).chain([false, false])
             .collect();

--- a/verifiable-circuit-babe/src/instance/secret.rs
+++ b/verifiable-circuit-babe/src/instance/secret.rs
@@ -4,7 +4,7 @@ use garbled_snark_verifier::bag::S;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use rand_chacha::rand_core::RngCore;
-use crate::dre::{N, utils::sample_rhos};
+use crate::dre::{N, N_PADDED, utils::sample_rhos};
 
 pub struct InstanceSecrets {
     /// 2 deltas for 2 garbled circuits
@@ -12,8 +12,8 @@ pub struct InstanceSecrets {
     pub r:             Fr,
     pub msg:           [u8; 32],
     /// label0 per input wire, for 2 circuits
-    /// fgc input size = 2 * N // pi_1
-    /// sgc input size = N // x_d
+    /// fgc input size = 2 * N_PADDED // pi_1
+    /// sgc input size = N_PADDED // x_d
     pub input_0labels: [Vec<S>; 2],
     /// Constant 0labels.
     /// fgc size = 2 (0/1)
@@ -30,7 +30,7 @@ pub fn derive_light_from_seed(seed: u64) -> ([S; 2], [Vec<S>; 2]) {
     let delta = [gen_s(&mut rng, 1)[0], gen_s(&mut rng, 1)[0]];
     let _ = Fr::rand(&mut rng);          // advance past r
     rng.fill_bytes(&mut [0u8; 32]);      // advance past msg
-    let input_0labels = [gen_s(&mut rng, 2 * N), gen_s(&mut rng, N)];
+    let input_0labels = [gen_s(&mut rng, 2 * N_PADDED), gen_s(&mut rng, N_PADDED)];
     (delta, input_0labels)
 }
 
@@ -45,7 +45,7 @@ impl InstanceSecrets {
         let mut msg = [0u8; 32];
         rng.fill_bytes(&mut msg);
 
-        let input_0labels = [gen_s(&mut rng, 2 * N), gen_s(&mut rng, N)];
+        let input_0labels = [gen_s(&mut rng, 2 * N_PADDED), gen_s(&mut rng, N_PADDED)];
 
         let constant_val_labels = [gen_s(&mut rng, 2), gen_s(&mut rng, 2 + 2 * N)];
 

--- a/verifiable-circuit-babe/src/prover.rs
+++ b/verifiable-circuit-babe/src/prover.rs
@@ -11,9 +11,9 @@ use garbled_snark_verifier::dv_bn254::fr::Fr as DvFr;
 use crate::babe::{WeKnownPi1ProveCt, WeKnownPi1SetupCt};
 use crate::cac::{CACSetupPackage, FinalizedInstanceData};
 use crate::dre::matrices::u_bar_vec;
-use crate::dre::{N_PADDED};
+use crate::dre::{N, N_PADDED};
 use crate::gc::{SparseAdaptorTable, SGC_PART1_CONSTANT_SIZE};
-use crate::instance::{b_value_bits, set_gc_const_labels};
+use crate::instance::{b_value_bits, set_gc_const_labels, set_sgc2_rq_eval_labels};
 use crate::soldering::{SolderedLabelsData, SolderingData};
 use crate::utils::{derive_hashlock, h_160, h_256, ro_from_pairing_bytes};
 
@@ -285,7 +285,7 @@ impl BABEProver {
         for (i, bit) in b_y_bits.iter().enumerate() {
             sgc.0[2 + 254 + i].borrow_mut().value = Some(*bit);
         }
-        let sgc_part1_witness: Vec<bool> = DvFr::to_bits(x_d);
+        let sgc_part1_witness: Vec<bool> = DvFr::to_bits(x_d).into_iter().chain([false, false]).collect();
         let sgc_output_labels_1 = BABEProver::eval_circuit_with_ciphertext(
             sgc,
             sgc_indices,
@@ -298,14 +298,10 @@ impl BABEProver {
         let q = self.vk.gamma_abc_g1[2] * self.dyn_pubin + b;
         let q_affine = q.into_affine();
         fgc.reset_circuit_except_01_constants();
-        // set label of part2 as output of part1 (evaluator has one active label per wire)
-        for (i, &key) in sgc_output_labels_1.iter().enumerate()  {
-            fgc.0[2 + i].borrow_mut().label = Some(S(key));
-        }
         set_gc_const_labels(fgc, &const_labels[1][0..2]);
-        let sgc_witness: Vec<bool> = DvFq::to_bits(q_affine.x)
-            .into_iter()
-            .chain(DvFq::to_bits(q_affine.y).into_iter())
+        set_sgc2_rq_eval_labels(fgc, &sgc_output_labels_1, const_labels[1][0]);
+        let sgc_witness: Vec<bool> = DvFq::to_bits(q_affine.x).into_iter().chain([false, false])
+            .chain(DvFq::to_bits(q_affine.y)).chain([false, false])
             .collect();
         let sgc_output_labels_2 = BABEProver::eval_circuit_with_ciphertext(
             fgc,

--- a/verifiable-circuit-babe/src/prover.rs
+++ b/verifiable-circuit-babe/src/prover.rs
@@ -11,7 +11,7 @@ use garbled_snark_verifier::dv_bn254::fr::Fr as DvFr;
 use crate::babe::{WeKnownPi1ProveCt, WeKnownPi1SetupCt};
 use crate::cac::{CACSetupPackage, FinalizedInstanceData};
 use crate::dre::matrices::u_bar_vec;
-use crate::dre::N;
+use crate::dre::{N_PADDED};
 use crate::gc::{SparseAdaptorTable, SGC_PART1_CONSTANT_SIZE};
 use crate::instance::{b_value_bits, set_gc_const_labels};
 use crate::soldering::{SolderedLabelsData, SolderingData};
@@ -170,7 +170,7 @@ impl BABEProver {
                 .iter()
                 .enumerate()
                 .map(|(j, &lbl)| {
-                    let idx = 2 * N + j;
+                    let idx = 2 * N_PADDED + j;
                     let (d0, d1) = deltas_i[idx];
                     if h_256(&lbl.0) == sld.base_commitment[idx].0 {
                         lbl ^ S(d0)

--- a/verifiable-circuit-babe/src/prover.rs
+++ b/verifiable-circuit-babe/src/prover.rs
@@ -256,9 +256,8 @@ impl BABEProver {
         for (i, &lbl) in p1_labels.iter().enumerate() {
             fgc.0[i + 2].borrow_mut().label = Some(lbl);
         }
-        let fgc_witness: Vec<bool> = DvFq::to_bits(pi1.x)
-            .into_iter()
-            .chain(DvFq::to_bits(pi1.y).into_iter())
+        let fgc_witness: Vec<bool> = DvFq::to_bits(pi1.x).into_iter().chain([false, false])
+            .chain(DvFq::to_bits(pi1.y)).chain([false, false])
             .collect();
         let fgc_output_labels = BABEProver::eval_circuit_with_ciphertext(
             fgc,

--- a/verifiable-circuit-babe/src/transactions.rs
+++ b/verifiable-circuit-babe/src/transactions.rs
@@ -41,10 +41,9 @@ pub struct TxAssertWitness {
 }
 
 impl TxAssertWitness {
-    /// Extract π₁ and x_d from the digit values embedded in the Wots96 signature.
-    /// The 96-byte message layout is: π₁.x (LE-32) ∥ π₁.y (LE-32) ∥ x_d (LE-32).
-    /// Return None if the wots_sig is wrong format, which not signature over (G1Affine, Fr)
-    pub fn recover_pi1_xd_without_verify(&self) -> Option<(G1Affine, Fr)> {
+    /// Check that the Assert witness is in the correct format and recover (π₁, x_d).
+    /// Returns None if the 96-byte message does not decode to a valid (G1Affine, Fr) pair
+    pub fn try_recover_pi1_xd(&self) -> Option<(G1Affine, Fr)> {
         // wrong length
         if self.wots_sig.len() != Wots96::TOTAL_DIGIT_LEN as usize {
             return None;
@@ -80,7 +79,7 @@ impl TxAssertWitness {
         vk: &Groth16VerifyingKey<Bn254>,
         static_public_inputs: &[Fr],
     ) -> bool {
-        let (pi1, x_d) = match self.recover_pi1_xd_without_verify() {
+        let (pi1, x_d) = match self.try_recover_pi1_xd() {
             Some(v) => v,
             None => return false,
         };
@@ -230,7 +229,7 @@ mod tests {
         TxAssertWitness { wots_sig: Wots96::sign(&sk, msg).to_vec(), pi2: vec![], pi3: vec![] }
     }
 
-    // ── recover_pi1_xd_without_verify ─────────────────────────────────────────
+    // ── try_recover_pi1_xd ─────────────────────────────────────────
 
     #[test]
     fn test_recover_valid_generator_and_fr() {
@@ -239,7 +238,7 @@ mod tests {
         let msg = pi1_xd_to_wots96_msg(&pi1, x_d);
         let witness = make_witness_from_raw_msg(&msg);
 
-        let (recovered_pi1, recovered_xd) = witness.recover_pi1_xd_without_verify().unwrap();
+        let (recovered_pi1, recovered_xd) = witness.try_recover_pi1_xd().unwrap();
         assert_eq!(recovered_pi1, pi1);
         assert_eq!(recovered_xd, x_d);
     }
@@ -250,19 +249,19 @@ mod tests {
             wots_sig: vec![[0u8; 21]; Wots96::TOTAL_DIGIT_LEN as usize - 1],
             pi2: vec![], pi3: vec![],
         };
-        assert!(witness.recover_pi1_xd_without_verify().is_none());
+        assert!(witness.try_recover_pi1_xd().is_none());
 
         let witness = TxAssertWitness {
             wots_sig: vec![[0u8; 21]; Wots96::TOTAL_DIGIT_LEN as usize + 1],
             pi2: vec![], pi3: vec![],
         };
-        assert!(witness.recover_pi1_xd_without_verify().is_none());
+        assert!(witness.try_recover_pi1_xd().is_none());
     }
 
     #[test]
     fn test_recover_empty_sig() {
         let witness = TxAssertWitness { wots_sig: vec![], pi2: vec![], pi3: vec![] };
-        assert!(witness.recover_pi1_xd_without_verify().is_none());
+        assert!(witness.try_recover_pi1_xd().is_none());
     }
 
     #[test]
@@ -276,7 +275,7 @@ mod tests {
         Fq::from(1u64).serialize_uncompressed(&mut buf).unwrap();
         msg[32..64].copy_from_slice(&buf);
         let witness = make_witness_from_raw_msg(&msg);
-        assert!(witness.recover_pi1_xd_without_verify().is_none());
+        assert!(witness.try_recover_pi1_xd().is_none());
     }
 
     #[test]
@@ -285,7 +284,7 @@ mod tests {
         let mut msg = [0u8; 96];
         msg[0..32].fill(0xFF);
         let witness = make_witness_from_raw_msg(&msg);
-        assert!(witness.recover_pi1_xd_without_verify().is_none());
+        assert!(witness.try_recover_pi1_xd().is_none());
     }
 
     #[test]
@@ -297,7 +296,7 @@ mod tests {
         msg[0..32].copy_from_slice(&buf);
         msg[32..64].fill(0xFF); // y > Fq modulus
         let witness = make_witness_from_raw_msg(&msg);
-        assert!(witness.recover_pi1_xd_without_verify().is_none());
+        assert!(witness.try_recover_pi1_xd().is_none());
     }
 
     #[test]
@@ -306,7 +305,7 @@ mod tests {
         let mut msg = pi1_xd_to_wots96_msg(&pi1, Fr::from(0u64));
         msg[64..96].fill(0xFF); // x_d > Fr modulus
         let witness = make_witness_from_raw_msg(&msg);
-        assert!(witness.recover_pi1_xd_without_verify().is_none());
+        assert!(witness.try_recover_pi1_xd().is_none());
     }
 
     // ── recover_pi2_pi3 ───────────────────────────────────────────────────────

--- a/verifiable-circuit-babe/src/transactions.rs
+++ b/verifiable-circuit-babe/src/transactions.rs
@@ -215,7 +215,7 @@ impl OnchainSize for TxWithdrawWitness {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ark_bn254::{Fq, Fr, G1Affine, G2Affine};
+    use ark_bn254::{Fq, Fr, G1Affine};
     use ark_ec::{AffineRepr, CurveGroup};
     use ark_ff::UniformRand;
     use ark_serialize::CanonicalSerialize;

--- a/verifiable-circuit-babe/src/verifier.rs
+++ b/verifiable-circuit-babe/src/verifier.rs
@@ -29,9 +29,8 @@ impl InstanceLightSecrets {
 
     pub fn compute_pi1_labels(&self, pi1: G1Affine) -> Vec<S> {
         let delta = self.delta[0];
-        DvFq::to_bits(pi1.x)
-            .into_iter()
-            .chain(DvFq::to_bits(pi1.y))
+        DvFq::to_bits(pi1.x).into_iter().chain([false, false])
+            .chain(DvFq::to_bits(pi1.y)).chain([false, false])
             .enumerate()
             .map(|(i, b)| {
                 let key = self.input_0labels[0][i];
@@ -42,8 +41,7 @@ impl InstanceLightSecrets {
 
     pub fn compute_x_d_labels(&self, x_d: Fr) -> Vec<S> {
         let delta = self.delta[1];
-        DvFr::to_bits(x_d)
-            .into_iter()
+        DvFr::to_bits(x_d).into_iter().chain([false, false])
             .enumerate()
             .map(|(i, b)| {
                 let key = self.input_0labels[1][i];

--- a/verifiable-circuit-babe/src/verifier.rs
+++ b/verifiable-circuit-babe/src/verifier.rs
@@ -5,6 +5,7 @@ use garbled_snark_verifier::dv_bn254::fq::Fq as DvFq;
 use garbled_snark_verifier::dv_bn254::fr::Fr as DvFr;
 use serde::{Deserialize, Serialize};
 use crate::cac::CACSetupPackage;
+use crate::dre::N_PADDED;
 use crate::gc::SGC_PART1_CONSTANT_SIZE;
 use crate::instance::CACInstance;
 use crate::instance::commit::CACInstanceCommit;
@@ -49,6 +50,26 @@ impl InstanceLightSecrets {
                 if b { key ^ delta } else { key }
             })
             .collect()
+    }
+
+    /// Build labels for all 3*N_PADDED input bits from the raw 96-byte Wots message.
+    /// Layout: pi1.x | pi1.y | x_d (each contains N_PADDED bits).
+    /// Same as serialize_uncompressed byte
+    pub fn compute_labels_from_bytes(&self, raw: &[u8; 96]) -> Vec<S> {
+        let delta_fgc = self.delta[0];
+        let delta_sgc = self.delta[1];
+        let mut labels = Vec::with_capacity(3 * N_PADDED);
+        for i in 0..2 * N_PADDED {
+            let bit = (raw[i / 8] >> (i % 8)) & 1;
+            let key = self.input_0labels[0][i];
+            labels.push(if bit == 1 { key ^ delta_fgc } else { key });
+        }
+        for i in 0..N_PADDED {
+            let bit = (raw[64 + i / 8] >> (i % 8)) & 1;
+            let key = self.input_0labels[1][i];
+            labels.push(if bit == 1 { key ^ delta_sgc } else { key });
+        }
+        labels
     }
 }
 
@@ -202,6 +223,12 @@ impl BABEVerifier {
     pub fn compute_x_d_labels(&self, idx: usize, x_d: Fr) -> Vec<S> {
         let ls = InstanceLightSecrets::from_seed(self.seeds[idx]);
         ls.compute_x_d_labels(x_d)
+    }
+
+    /// Compute all input labels for instance `idx` from the raw 96-byte Wots message.
+    pub fn compute_labels_from_bytes(&self, idx: usize, raw: &[u8; 96]) -> Vec<S> {
+        let ls = InstanceLightSecrets::from_seed(self.seeds[idx]);
+        ls.compute_labels_from_bytes(raw)
     }
 
     pub fn get_seeds(&self) -> Vec<u64> {


### PR DESCRIPTION
**Summary**:
- Increase the input size of GCs from 762 to 768 to validate the Assert witness inside circuits
- Construct the ChallengeAssert witness directly from Assert witness, without converting to G1Affine or Fr, to properly handle invalid Assert witness submissions.

**Tests**: all tests are passed.